### PR TITLE
depend on babel-core rather than full cli

### DIFF
--- a/bin/babel-tape-runner
+++ b/bin/babel-tape-runner
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-require('babel/register')
+require('babel-core/register')
 var path = require('path')
 var glob = require('glob')
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "glob": "^4.4.1"
   },
   "peerDependencies": {
-    "babel": "*"
+    "babel-core": "*",
   }
 }


### PR DESCRIPTION
does not actually need anything outside of core and depending on core directly is more inline with what babel-loader etc is doing
