### PR TITLE
Enable ignoring of CSS that gets compiled by Babel

### DIFF
--- a/bin/babel-tape-runner
+++ b/bin/babel-tape-runner
@@ -5,9 +5,23 @@ require('babel-polyfill')
 var path = require('path')
 var glob = require('glob')
 
-process.argv.slice(2).forEach(function (arg) {
+var fileFlags = ['-f', '--files', '--file']
+var noCSSFlags = ['-nc', '--no-css']
 
-  if (arg === '-f' || arg === '--files' || arg === '--file') {
+function isFileFlag (arg) {
+  return fileFlags.some(function (flag) {
+    return arg === flag
+  })
+}
+
+function isNoCSSFlag (arg) {
+  return noCSSFlags.some(function (flag) {
+    return arg === flag
+  })
+}
+
+process.argv.slice(2).forEach(function (arg, index) {
+  if (isFileFlag(arg)) {
     glob(process.argv[index + 3], function (er, files) {
       if (er) throw er
 
@@ -15,10 +29,9 @@ process.argv.slice(2).forEach(function (arg) {
         require(path.resolve(process.cwd(), file))
       })
     })
-  } else if (arg === '-nc' || arg === '--no-css') {
-    require('ignore-styles');
+  } else if (isNoCSSFlag(arg)) {
+    require('ignore-styles')
   }
-
 })
 
 // vim: ft=javascript

--- a/bin/babel-tape-runner
+++ b/bin/babel-tape-runner
@@ -7,7 +7,7 @@ var glob = require('glob')
 
 process.argv.slice(2).forEach(function (arg) {
 
-  if (arg === '-f' || arg === '--files') {
+  if (arg === '-f' || arg === '--files' || arg === '--file') {
     glob(process.argv[index + 3], function (er, files) {
       if (er) throw er
 

--- a/bin/babel-tape-runner
+++ b/bin/babel-tape-runner
@@ -6,13 +6,19 @@ var path = require('path')
 var glob = require('glob')
 
 process.argv.slice(2).forEach(function (arg) {
-  glob(arg, function (er, files) {
-    if (er) throw er
 
-    files.forEach(function (file) {
-      require(path.resolve(process.cwd(), file))
+  if (arg === '-f' || arg === '--files') {
+    glob(process.argv[index + 3], function (er, files) {
+      if (er) throw er
+
+      files.forEach(function (file) {
+        require(path.resolve(process.cwd(), file))
+      })
     })
-  })
+  } else if (arg === '-nc' || arg === '--no-css') {
+    require('ignore-styles');
+  }
+
 })
 
 // vim: ft=javascript

--- a/bin/babel-tape-runner
+++ b/bin/babel-tape-runner
@@ -5,14 +5,33 @@ require('babel-polyfill')
 var path = require('path')
 var glob = require('glob')
 
-process.argv.slice(2).forEach(function (arg) {
-  glob(arg, function (er, files) {
-    if (er) throw er
+var fileFlags = ['-f', '--files', '--file']
+var noCSSFlags = ['-nc', '--no-css']
 
-    files.forEach(function (file) {
-      require(path.resolve(process.cwd(), file))
-    })
+function isFileFlag (arg) {
+  return fileFlags.some(function (flag) {
+    return arg === flag
   })
+}
+
+function isNoCSSFlag (arg) {
+  return noCSSFlags.some(function (flag) {
+    return arg === flag
+  })
+}
+
+process.argv.slice(2).forEach(function (arg, index) {
+  if (isFileFlag(arg)) {
+    glob(process.argv[index + 3], function (er, files) {
+      if (er) throw er
+
+      files.forEach(function (file) {
+        require(path.resolve(process.cwd(), file))
+      })
+    })
+  } else if (isNoCSSFlag(arg)) {
+    require('ignore-styles')
+  }
 })
 
 // vim: ft=javascript

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "babel-polyfill": "^6.3.14",
     "babel-register": "^6.3.13",
-    "glob": "^6.0.1"
+    "glob": "^6.0.1",
+    "ignore-styles": "^3.0.0"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.3.13",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "pretest": "cp .testbabelrc .babelrc",
-    "test": "standard bin/babel-tape-runner test.js && node bin/babel-tape-runner test.js",
+    "test": "standard bin/babel-tape-runner -f test.js && node bin/babel-tape-runner -f test.js",
     "posttest": "rm .babelrc"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "pretest": "cp .testbabelrc .babelrc",
-    "test": "standard bin/babel-tape-runner test.js && node bin/babel-tape-runner test.js",
+    "test": "standard bin/babel-tape-runner -f test.js && node bin/babel-tape-runner -f test.js",
     "posttest": "rm .babelrc"
   },
   "keywords": [
@@ -30,7 +30,8 @@
   "dependencies": {
     "babel-polyfill": "^6.3.14",
     "babel-register": "^6.3.13",
-    "glob": "^6.0.1"
+    "glob": "^6.0.1",
+    "ignore-styles": "^3.0.0"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.3.13",

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ babel-tape-runner --file my-es-next-test.js
 
 babel-tape-runner --files lib/**/__tests__/*-test.js # or glob patterns
 
-bable-tape-runner --files lib/**/__tests__/*-test.js --no-css # to ignore css that's being compiled by babel
+babel-tape-runner --files lib/**/__tests__/*-test.js --no-css # to ignore css that's being compiled by babel
 ```
 
 For example, use this in your `package.json` file so you can run `npm test` to execute your tests:

--- a/readme.md
+++ b/readme.md
@@ -20,9 +20,11 @@ npm install babel-tape-runner [-g]
 Just run `babel-tape-runner` with the files to test (just like tape's bundled runner).  Store configuration in a `.babelrc` file.
 
 ```sh
-babel-tape-runner my-es-next-test.js
+babel-tape-runner --file my-es-next-test.js
 
-babel-tape-runner lib/**/__tests__/*-test.js # or glob patterns
+babel-tape-runner --files lib/**/__tests__/*-test.js # or glob patterns
+
+bable-tape-runner --files lib/**/__tests__/*-test.js --no-css # to ignore css that's being compiled by babel
 ```
 
 For example, use this in your `package.json` file so you can run `npm test` to execute your tests:

--- a/test.js
+++ b/test.js
@@ -4,6 +4,6 @@ import test from 'tape'
 test('babel-tape-runner', t => {
   let file = readFileSync(__filename, 'utf8')
   t.ok(/hello/gim.flags, 'gim')
-  t.ok(/^import/.test(file))
+  t.ok(/^import/.test(file), 'import file')
   t.end()
 })


### PR DESCRIPTION
**This one is a major change and will break the API**, so I get if you don't want to merge. Basically it will enable support of ignoring css files that babel imports. 
- Introduces a dependency on the `ignore-styles` package
- This allows us to easily support ignoring css when babel is also used to compile css
- Ideally we would expose `babel-register` and create a more elegant implementation, but this is a quick fix for anyone out there that was stuck like me
